### PR TITLE
Add missing httpx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -e .
+httpx
 ruff==0.2.0
 pytest
 pytest-asyncio


### PR DESCRIPTION
This PR adds a missing `httpx` dependency, which is essential for testing purposes.

Closes #2 